### PR TITLE
Removed extraneous spot cost for 1R128

### DIFF
--- a/gemp-lotr/gemp-lotr-cards/src/main/java/com/gempukku/lotro/cards/set1/isengard/Card1_128.java
+++ b/gemp-lotr/gemp-lotr-cards/src/main/java/com/gempukku/lotro/cards/set1/isengard/Card1_128.java
@@ -30,12 +30,6 @@ public class Card1_128 extends AbstractOldEvent {
     }
 
     @Override
-    public boolean checkPlayRequirements(String playerId, LotroGame game, PhysicalCard self, int withTwilightRemoved, int twilightModifier, boolean ignoreRoamingPenalty, boolean ignoreCheckingDeadPile) {
-        return super.checkPlayRequirements(playerId, game, self, withTwilightRemoved, twilightModifier, ignoreRoamingPenalty, ignoreCheckingDeadPile)
-                && Filters.canSpot(game.getGameState(), game.getModifiersQuerying(), Race.URUK_HAI);
-    }
-
-    @Override
     public PlayEventAction getPlayCardAction(String playerId, LotroGame game, final PhysicalCard self, int twilightModifier, boolean ignoreRoamingPenalty) {
         final PlayEventAction action = new PlayEventAction(self);
 


### PR DESCRIPTION
I couldn't find any note that there should be a spot cost for Lurtz's Battle Cry. Feel free to veto this if there's a reason for it.