### PR TITLE
Ford of Bruinen

### DIFF
--- a/gemp-lotr/gemp-lotr-async/src/main/web/cards/set1/set1-isengard.json
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/cards/set1/set1-isengard.json
@@ -958,23 +958,18 @@
     "effects": {
       "type": "activated",
       "phase": "skirmish",
-      "condition": {
-        "type": "perPhaseLimit",
-        "limit": 3
+      "cost": {
+        "type": "removeTwilight"
       },
-      "cost": [
-        {
-          "type": "incrementPerPhaseLimit",
-          "limit": 3
-        },
-        {
-          "type": "removeTwilight"
-        }
-      ],
       "effect": {
         "type": "modifyStrength",
         "filter": "self",
-        "amount": 1
+        "amount": {
+          "type": "cardAffectedLimitPerPhase",
+          "prefix": "str-",
+          "source": 1,
+          "limit": 3
+        }
       }
     }
   },

--- a/gemp-lotr/gemp-lotr-async/src/main/web/cards/set1/set1.json
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/cards/set1/set1.json
@@ -569,6 +569,20 @@
         "effect": {
           "type": "resetWhileInZoneData"
         }
+      },
+      {
+        "type": "trigger",
+        "trigger": {
+          "type": "movesFrom",
+          "filter": "self"
+        },
+        "condition": {
+          "type": "phase",
+          "phase": "regroup"
+        },
+        "effect": {
+          "type": "resetWhileInZoneData"
+        }
       }
     ]
   },

--- a/gemp-lotr/gemp-lotr-async/src/main/web/cards/set31/set31-fp.json
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/cards/set31/set31-fp.json
@@ -519,6 +519,11 @@
         },
         "cost": [
           {
+            "type": "memorize",
+            "filter": "bearer",
+            "memory": "bearer"
+          },
+          {
             "type": "transferToSupport",
             "filter": "self"
           }
@@ -527,11 +532,11 @@
           "type": "conditional",
           "condition": {
             "type": "canSpot",
-            "filter": "inSkirmish,mounted,orc"
+            "filter": "inSkirmish,hasAttached(mount),orc"
           },
           "effect": {
             "type": "cancelSkirmish",
-            "filter": "bearer"
+            "filter": "memory(bearer)"
           }
         }
       }

--- a/gemp-lotr/gemp-lotr-async/src/main/web/cards/set31/set31-fp.json
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/cards/set31/set31-fp.json
@@ -519,11 +519,6 @@
         },
         "cost": [
           {
-            "type": "memorize",
-            "filter": "bearer",
-            "memory": "bearer"
-          },
-          {
             "type": "transferToSupport",
             "filter": "self"
           }
@@ -536,7 +531,7 @@
           },
           "effect": {
             "type": "cancelSkirmish",
-            "filter": "memory(bearer)"
+            "filter": "bearer"
           }
         }
       }
@@ -556,13 +551,13 @@
       "effect": [
         {
           "type": "modifyStrength",
-          "filter": "all(culture(dwarven),companion,hasStacked(follower))",
+          "filter": "all(culture(dwarven),companion,hasAttached(follower))",
           "amount": 2,
           "until": "start(regroup)"
         },
         {
           "type": "addKeyword",
-          "filter": "all(culture(dwarven),companion,hasStacked(and(follower,culture(gandalf))))",
+          "filter": "all(culture(dwarven),companion,hasAttached(and(follower,culture(gandalf))))",
           "keyword": "defender+1",
           "until": "start(regroup)"
         }

--- a/gemp-lotr/gemp-lotr-async/src/main/web/cards/set31/set31-shadow.json
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/cards/set31/set31-shadow.json
@@ -82,7 +82,7 @@
         "cost": [
           {
             "type": "exert",
-            "filter": "choose(name(Gollum),not(roaming))"
+            "filter": "choose(self,not(roaming))"
           },
           {
             "type": "assignFpCharacterToSkirmish",
@@ -304,7 +304,7 @@
   "31_26": {
     "title": "Threatening Warg",
     "culture": "gundabad",
-    "cost": 3,
+    "cost": 4,
     "type": "possession",
     "possession": "mount",
     "strength": 4,
@@ -1157,7 +1157,7 @@
   "31_65": {
     "title": "Caught in a Sack",
     "culture": "troll",
-    "cost": 2,
+    "cost": 0,
     "type": "condition",
     "keyword": "support area",
     "effects": [

--- a/gemp-lotr/gemp-lotr-async/src/main/web/cards/set31/set31-shadow.json
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/cards/set31/set31-shadow.json
@@ -265,7 +265,7 @@
     }
   },
   "31_25": {
-    "title": "Savage Worg",
+    "title": "Savage Warg",
     "culture": "gundabad",
     "cost": 3,
     "type": "possession",

--- a/gemp-lotr/gemp-lotr-async/src/main/web/cards/set32/set32-fp.json
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/cards/set32/set32-fp.json
@@ -110,7 +110,7 @@
       "type": "modifier",
       "modifier": {
         "type": "modifyStrength",
-        "filter": "bearer,inSkirmishAgainst(mounted,minion)",
+        "filter": "bearer,inSkirmishAgainst(hasAttached(mount),minion)",
         "amount": 1
       }
     }

--- a/gemp-lotr/gemp-lotr-async/src/main/web/cards/set32/set32-shadow.json
+++ b/gemp-lotr/gemp-lotr-async/src/main/web/cards/set32/set32-shadow.json
@@ -455,7 +455,7 @@
         "phase": "regroup",
         "condition": {
           "type": "cantSpot",
-          "filter": "self,mounted"
+          "filter": "self,hasAttached(mount)"
         },
         "cost": {
           "type": "exert",
@@ -640,7 +640,7 @@
         "phase": "regroup",
         "condition": {
           "type": "cantSpot",
-          "filter": "self,mounted"
+          "filter": "self,hasAttached(mount)"
         },
         "cost": {
           "type": "exert",
@@ -738,7 +738,7 @@
         "phase": "regroup",
         "condition": {
           "type": "cantSpot",
-          "filter": "self,mounted"
+          "filter": "self,hasAttached(mount)"
         },
         "cost": {
           "type": "exert",


### PR DESCRIPTION
Currently Ford of Bruinen won't reset data if a player moves from it in the Regroup phase, meaning the second player won't get the discount. I guess in the new system, sites are totally inactive if they're not the current site? It may also be possible that the discount extends to the next site if a player doesn't play anything at Fords of Bruinen, I haven't checked.

I have confirmed that this change works, but maybe it should be addressed on the rules side of things rather than the card itself since it could create problems with sites down the line. I just have no idea where to begin with that.